### PR TITLE
fix bug

### DIFF
--- a/garnet/client.py
+++ b/garnet/client.py
@@ -189,7 +189,7 @@ class TelegramClient(_TelethonTelegramClient, ctx.ContextInstanceMixin):
 
         if _has_state_checker is False and self.storage is not None:
             filters = list(filters)
-            filters.append(~(state == all))
+            filters.append(~(state.CurrentState == all))
             filters = tuple(filters)
 
         elif _has_state_checker and self.storage is None:


### PR DESCRIPTION
Fixes bug that appears when using the storage

```
ERROR:asyncio:Task exception was never retrieved
future: <Task finished name='Task-10' coro=<TelegramClient._dispatch_update() done, defined at /usr/local/lib/python3.8/site-packages/garnet/client.py:211> exception=AttributeError("'int' object has no attribute 'key_maker'")>

Traceback (most recent call last):
File "/usr/local/lib/python3.8/site-packages/garnet/client.py", line 252, in <lambda>

& (f_.key_maker is not None),

AttributeError: 'int' object has no attribute 'key_maker'
```