### PR TITLE
handle commands with bot username

### DIFF
--- a/garnet/filters/text.py
+++ b/garnet/filters/text.py
@@ -33,7 +33,7 @@ def commands(
     return Filter(
         lambda update: isinstance(update.text, str)
         and any(update.text.startswith(prefix) for prefix in prefixes)
-        and update.text.split()[0][1:] in cmd
+        and update.text.split()[0][1:].split('@')[0] in cmd
     )
 
 


### PR DESCRIPTION
In Group conversations, there will be many bots. So `/some-command-here@my-bot` will only work.
Remove `@my-bot` part before comparing with list of commands